### PR TITLE
[FIX] #7 node_modules with .js in the name

### DIFF
--- a/dummy.js/package.json
+++ b/dummy.js/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "dummy.js",
+    "version": "1.0.0",
+    "private": true
+}

--- a/index.js
+++ b/index.js
@@ -49,10 +49,15 @@ function resolveFile(source, file, config) {
   }
 
   // note that even if we match via tsconfig-paths, we still need to do a final resolve
-  const foundNodePath = resolve.sync(foundTsPath || source, {
-    extensions,
-    basedir: path.dirname(path.resolve(file)),
-  })
+  let foundNodePath;
+  try {
+    foundNodePath = resolve.sync(foundTsPath || source, {
+      extensions,
+      basedir: path.dirname(path.resolve(file)),
+    })
+  } catch (err) {
+    foundNodePath = null;
+  }
 
   if (foundNodePath) {
     log('matched node path:', foundNodePath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,6 +271,10 @@
         "esutils": "^2.0.2"
       }
     },
+    "dummy.js": {
+      "version": "file:dummy.js",
+      "dev": true
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     ],
     rules: {
         'import/no-unresolved': 'error',
+        'import/extensions': 'error',
     },
     settings: {
         'import/resolver': {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -12,3 +12,4 @@ import 'folder/subfolder/tsxImportee'
 
 // import from node_module
 import 'typescript'
+import 'dummy.js'


### PR DESCRIPTION
If the "import/extensions" rule is activated then the following import statement causes the error:
```
import "popper.js";
```
causes the following error
```
Resolve error: Cannot find module 'popper' from 'D:\Projects\eslint-import-resolver-typescript\tests'  import/extensions
```

This code is ported from the previous version of the file https://github.com/alexgorbatchev/eslint-import-resolver-typescript/commit/87a9e00f92c7313dda0e57b0b8ed8b0d74abef39#diff-168726dbe96b3ce427e7fedce31bb0bcL20

These changes fixes this error. I do not know how to test it correctly via unit test because we need to install some npm package with ".js" suffix in the name for this test.