### PR TITLE
Change recommended configuration to use plugin-specific parser rather than changing global parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ Add the following to your `.eslintrc` config:
 
 ```CJSON
 {
-  "parser": "typescript-eslint-parser",
   "plugins": ["import"],
   "rules": {
     // turn on errors for missing imports
     "import/no-unresolved": "error"
   },
   "settings": {
+    "import/parsers": {
+      "typescript-eslint-parser": [".ts", ".tsx"]
+    },
     "import/resolver": {
       // use <root>/tsconfig.json
       "typescript": {},
@@ -40,6 +42,7 @@ Add the following to your `.eslintrc` config:
   }
 }
 ```
+
 
 ## Contributing
 


### PR DESCRIPTION
We noticed some unrelated errors when changing the global parser, so this was the fix that worked in our case and follows the structure from the `eslint-plugin-import` docs to change the parser for `import` and restrict it to `.ts` and `.tsx` files.

https://github.com/benmosher/eslint-plugin-import#importparsers

