### PR TITLE
allow null config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ Add the following to your `.eslintrc` config:
     "import/parsers": {
       "@typescript-eslint/parser": [".ts", ".tsx"]
     },
-    "import/resolver": {
-      // use <root>/tsconfig.json
-      "typescript": {},
-
-      // use <root>/path/to/folder/tsconfig.json
+    
+    // use <root>/tsconfig.json:
+    "import/resolver": "typescript",
+    
+    // use <root>/path/to/folder/tsconfig.json:
+    "import/resolver: {
       "typescript": {
         "directory": "./path/to/folder"
       }

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function resolveFile(source, file, config) {
   );
 
   // setup tsconfig-paths
-  const searchStart = config.directory || process.cwd();
+  const searchStart = (config && config.directory) || process.cwd();
   const configLoaderResult = tsconfigPaths.loadConfig(searchStart);
   if (configLoaderResult.resultType === 'success') {
     const matchPath = tsconfigPaths.createMatchPath(


### PR DESCRIPTION
means you can specify this resolver using just `import/resolver: 'typescript'` instead of `import/resolver: {'typescript':{}}`:

![image](https://user-images.githubusercontent.com/3709196/57016176-b7188b80-6be6-11e9-8028-b534405d8fec.png)
