### PR TITLE
[FEAT] Support multiple tsconfigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,29 @@ Add the following to your `.eslintrc` config:
       // use <root>/path/to/folder/tsconfig.json
       "typescript": {
         "directory": "./path/to/folder"
+      },
+
+      // Multiple tsconfigs (Useful for monorepos)
+
+      // use a glob pattern
+      "typescript": {
+        "directory": "./packages/**/tsconfig.json"
+      },
+
+      // use an array
+      "typescript": {
+        "directory": [
+          "./packages/module-a/tsconfig.json",
+          "./packages/module-b/tsconfig.json"
+        ]
+      },
+
+      // use an array of glob patterns
+      "typescript": {
+        "directory": [
+          "./packages/**/tsconfig.json",
+          "./other-packages/**/tsconfig.json"
+        ]
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install --save-dev eslint-plugin-import @typescript-eslint/parser eslint-imp
 
 Add the following to your `.eslintrc` config:
 
-```CJSON
+```JSONC
 {
   "plugins": ["import"],
   "rules": {

--- a/index.js
+++ b/index.js
@@ -7,11 +7,17 @@ const debug = require('debug');
 
 const log = debug('eslint-import-resolver-typescript');
 
+const extensions = Object.keys(require.extensions).concat(
+  '.ts',
+  '.tsx',
+  '.d.ts',
+);
+
 /**
  * @param {string} source the module to resolve; i.e './some-module'
  * @param {string} file the importing file's full path; i.e. '/usr/local/bin/file.js'
  */
-function resolveFile(source, file, config) {
+function resolveFile(source, file, options = {}) {
   log('looking for:', source);
 
   // don't worry about core node modules
@@ -24,38 +30,16 @@ function resolveFile(source, file, config) {
     };
   }
 
-  let foundTsPath = null;
-  const extensions = Object.keys(require.extensions).concat(
-    '.ts',
-    '.tsx',
-    '.d.ts',
-  );
-
-  // setup tsconfig-paths
-  const searchStart = config.directory || process.cwd();
-  const configLoaderResult = tsconfigPaths.loadConfig(searchStart);
-  if (configLoaderResult.resultType === 'success') {
-    const matchPath = tsconfigPaths.createMatchPath(
-      configLoaderResult.absoluteBaseUrl,
-      configLoaderResult.paths,
-    );
-
-    // look for files based on setup tsconfig "paths"
-    foundTsPath = matchPath(source, undefined, undefined, extensions);
-
-    if (foundTsPath) {
-      log('matched ts path:', foundTsPath);
-    }
-  } else {
-    log('failed to init tsconfig-paths:', configLoaderResult.message);
-    // this can happen if the user has problems with their tsconfig
-    // or if it's valid, but they don't have baseUrl set
+  initMappers(options);
+  const mappedPath = getMappedPath(source, file);
+  if (mappedPath) {
+    log('matched ts path:', mappedPath);
   }
 
-  // note that even if we match via tsconfig-paths, we still need to do a final resolve
+  // note that even if we map the path, we still need to do a final resolve
   let foundNodePath;
   try {
-    foundNodePath = resolve.sync(foundTsPath || source, {
+    foundNodePath = resolve.sync(mappedPath || source, {
       extensions,
       basedir: path.dirname(path.resolve(file)),
       packageFilter,
@@ -79,11 +63,74 @@ function resolveFile(source, file, config) {
     found: false,
   };
 }
+
 function packageFilter(pkg) {
   if (pkg['jsnext:main']) {
     pkg['main'] = pkg['jsnext:main'];
   }
   return pkg;
+}
+
+/**
+ * @param {string} source the module to resolve; i.e './some-module'
+ * @param {string} file the importing file's full path; i.e. '/usr/local/bin/file.js'
+ * @returns The mapped path of the module or undefined
+ */
+function getMappedPath(source, file) {
+  const paths = mappers
+    .map(mapper => mapper(source, file))
+    .filter(path => !!path);
+
+  if (paths.length > 1) {
+    log('found multiple matching ts paths:', paths);
+  }
+
+  return paths[0];
+}
+
+let mappers;
+function initMappers(options) {
+  if (mappers) {
+    return;
+  }
+
+  const isArrayOfStrings = array =>
+    Array.isArray(array) && array.every(o => typeof o === 'string');
+
+  const configPaths =
+    typeof options.directory === 'string'
+      ? [options.directory]
+      : isArrayOfStrings(options.directory)
+      ? options.directory
+      : [process.cwd()];
+
+  mappers = configPaths
+    .map(path => tsconfigPaths.loadConfig(path))
+    .filter(configLoaderResult => {
+      const success = configLoaderResult.resultType === 'success';
+      if (!success) {
+        // this can happen if the user has problems with their tsconfig
+        // or if it's valid, but they don't have baseUrl set
+        log('failed to init tsconfig-paths:', configLoaderResult.message);
+      }
+      return success;
+    })
+    .map(configLoaderResult => {
+      const matchPath = tsconfigPaths.createMatchPath(
+        configLoaderResult.absoluteBaseUrl,
+        configLoaderResult.paths,
+      );
+
+      return (source, file) => {
+        // exclude files that are not part of the config base url
+        if (!file.includes(configLoaderResult.absoluteBaseUrl)) {
+          return undefined;
+        }
+
+        // look for files based on setup tsconfig "paths"
+        return matchPath(source, undefined, undefined, extensions);
+      };
+    });
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const path = require('path');
 const resolve = require('resolve');
 const tsconfigPaths = require('tsconfig-paths');
 const debug = require('debug');
+const globSync = require('glob').sync;
+const isGlob = require('is-glob');
 
 const log = debug('eslint-import-resolver-typescript');
 
@@ -105,6 +107,12 @@ function initMappers(options) {
       : [process.cwd()];
 
   mappers = configPaths
+    // turn glob patterns into paths
+    .reduce(
+      (paths, path) => paths.concat(isGlob(path) ? globSync(path) : path),
+      [],
+    )
+
     .map(path => tsconfigPaths.loadConfig(path))
     .filter(configLoaderResult => {
       const success = configLoaderResult.resultType === 'success';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-import-resolver-typescript",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -116,14 +116,12 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -206,8 +204,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -594,8 +591,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -610,10 +606,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -695,17 +690,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "6.2.0",
@@ -743,11 +736,24 @@
         "builtin-modules": "^1.0.0"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -804,9 +810,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -874,9 +880,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "mimic-fn": {
@@ -889,7 +895,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -961,7 +966,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1040,8 +1044,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -1109,6 +1112,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "progress": {
@@ -1446,8 +1455,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "license": "ISC",
   "dependencies": {
     "debug": "^4.0.1",
+    "glob": "^7.1.4",
+    "is-glob": "^4.0.1",
     "resolve": "^1.4.0",
     "tsconfig-paths": "^3.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^3.1.1"
   },
   "scripts": {
-    "test": "eslint ./tests/withPaths/index.ts && eslint ./tests/withoutPaths/index.ts",
+    "test": "eslint ./tests/withPaths/index.ts && eslint ./tests/withoutPaths/index.ts && eslint ./tests/multipleTsconfigs/**/index.ts",
     "check-format": "prettier --config prettier.config.js index.js -l",
     "format": "prettier --config prettier.config.js index.js --write"
   }

--- a/tests/multipleTsconfigs/.eslintrc.js
+++ b/tests/multipleTsconfigs/.eslintrc.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+const globPattern = './packages/**/tsconfig.json';
+
+// in normal cases this is not needed because the __dirname would be the root
+const absoluteGlobPath = path.join(__dirname, globPattern);
+
+module.exports = require('../baseEslintConfig')(absoluteGlobPath);

--- a/tests/multipleTsconfigs/packages/module-a/index.ts
+++ b/tests/multipleTsconfigs/packages/module-a/index.ts
@@ -1,0 +1,15 @@
+// import relative
+import './tsImportee'
+import './tsxImportee'
+import './subfolder/tsImportee'
+import './subfolder/tsxImportee'
+
+// import using tsconfig.json path mapping
+import 'folder/tsImportee'
+import 'folder/tsxImportee'
+import 'folder/subfolder/tsImportee'
+import 'folder/subfolder/tsxImportee'
+
+// import from node_module
+import 'typescript'
+import 'dummy.js'

--- a/tests/multipleTsconfigs/packages/module-a/subfolder/tsImportee.ts
+++ b/tests/multipleTsconfigs/packages/module-a/subfolder/tsImportee.ts
@@ -1,0 +1,1 @@
+export default 'yes'

--- a/tests/multipleTsconfigs/packages/module-a/subfolder/tsxImportee.tsx
+++ b/tests/multipleTsconfigs/packages/module-a/subfolder/tsxImportee.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'

--- a/tests/multipleTsconfigs/packages/module-a/tsImportee.ts
+++ b/tests/multipleTsconfigs/packages/module-a/tsImportee.ts
@@ -1,0 +1,1 @@
+export default 'yes'

--- a/tests/multipleTsconfigs/packages/module-a/tsconfig.json
+++ b/tests/multipleTsconfigs/packages/module-a/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "jsx": "react",
+        "paths": {
+            "folder/*": ["*"],
+            "*": ["../../../../node_modules/*"]
+        },
+    },
+    "files": [
+        "index.ts",
+        "tsImportee.ts",
+        "tsxImportee.tsx"
+    ]
+}

--- a/tests/multipleTsconfigs/packages/module-a/tsxImportee.tsx
+++ b/tests/multipleTsconfigs/packages/module-a/tsxImportee.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'

--- a/tests/multipleTsconfigs/packages/module-b/index.ts
+++ b/tests/multipleTsconfigs/packages/module-b/index.ts
@@ -1,0 +1,15 @@
+// import relative
+import './tsImportee'
+import './tsxImportee'
+import './subfolder/tsImportee'
+import './subfolder/tsxImportee'
+
+// import using tsconfig.json path mapping
+import 'folder/tsImportee'
+import 'folder/tsxImportee'
+import 'folder/subfolder/tsImportee'
+import 'folder/subfolder/tsxImportee'
+
+// import from node_module
+import 'typescript'
+import 'dummy.js'

--- a/tests/multipleTsconfigs/packages/module-b/subfolder/tsImportee.ts
+++ b/tests/multipleTsconfigs/packages/module-b/subfolder/tsImportee.ts
@@ -1,0 +1,1 @@
+export default 'yes'

--- a/tests/multipleTsconfigs/packages/module-b/subfolder/tsxImportee.tsx
+++ b/tests/multipleTsconfigs/packages/module-b/subfolder/tsxImportee.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'

--- a/tests/multipleTsconfigs/packages/module-b/tsImportee.ts
+++ b/tests/multipleTsconfigs/packages/module-b/tsImportee.ts
@@ -1,0 +1,1 @@
+export default 'yes'

--- a/tests/multipleTsconfigs/packages/module-b/tsconfig.json
+++ b/tests/multipleTsconfigs/packages/module-b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "jsx": "react",
+        "paths": {
+            "folder/*": ["*"],
+            "*": ["../../../../node_modules/*"]
+        },
+    },
+    "files": [
+        "index.ts",
+        "tsImportee.ts",
+        "tsxImportee.tsx"
+    ]
+}

--- a/tests/multipleTsconfigs/packages/module-b/tsxImportee.tsx
+++ b/tests/multipleTsconfigs/packages/module-b/tsxImportee.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'


### PR DESCRIPTION
closes #21

Adds support for multiple `tsconfig`s.
This enables aliasing via `compilerOptions.paths` for monorepos with multiple `tsconfig`s
Should also improve performance because the mappers are cached.

Includes a new test and updated docs.
I have also tested the new changes in my own typescript monorepo and everything works as expected.