### PR TITLE
Resolve files with jsx extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import debug from 'debug'
 
 const log = debug('eslint-import-resolver-ts')
 
-const extensions = ['.ts', '.tsx', '.d.ts'].concat(
+const extensions = ['.ts', '.tsx', '.d.ts', '.jsx'].concat(
   // eslint-disable-next-line node/no-deprecated-api
   Object.keys(require.extensions),
 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,10 @@ import debug from 'debug'
 
 const log = debug('eslint-import-resolver-ts')
 
-const extensions = ['.ts', '.tsx', '.d.ts', '.jsx'].concat(
+const extensions = ['.ts', '.tsx', '.d.ts'].concat(
   // eslint-disable-next-line node/no-deprecated-api
   Object.keys(require.extensions),
+  '.jsx',
 )
 
 export const interfaceVersion = 2


### PR DESCRIPTION
Closes https://github.com/alexgorbatchev/eslint-import-resolver-typescript/issues/25

As discussed, this makes it possible to resolve files with `.jsx` extension, when using `allowJs` option.