### PR TITLE
fix: remove .tsbuildinfo and d.ts.map files from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "fesm5": "lib/esm",
   "types": "lib",
   "files": [
-    "lib"
+    "lib/*.{js,js.map,d.ts}"
   ],
   "keywords": [
     "typescript",


### PR DESCRIPTION
I was doing a script to remove all `.tsbuildinfo` files from my monorepo and noted that this package is distributing those files. I got something like this:

```sh
$ find . -name '*.tsbuildinfo'
./node_modules/eslint-import-resolver-typescript/lib/tsconfig.tsbuildinfo
./packages/A/dist/tsconfig.tsbuildinfo
./packages/B/dist/tsconfig.tsbuildinfo
./packages/C/dist/tsconfig.tsbuildinfo
```

I think those files shouldn't be distributed, so I've filtered them out of the package. I've also left out `.d.ts.map` files, as they are unusable without the original sources, which are not distributed on the package.

I **don't** think we should stop generating `.tsbuildinfo` and `.d.ts.map` files, as they are useful for build performance and development experience. We should just not distribute them.