### PR TITLE
feat: remove any querystring from imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:multipleTsconfigs": "eslint --ext ts,tsx tests/multipleTsconfigs",
     "test:withJsExtension": "node tests/withJsExtension/test.js && eslint --ext ts,tsx tests/withJsExtension",
     "test:withPaths": "eslint --ext ts,tsx tests/withPaths",
+    "test:withQuerystring": "eslint --ext ts,tsx tests/withQuerystring",
     "test:withoutPaths": "eslint --ext ts,tsx tests/withoutPaths",
     "type-coverage": "type-coverage --cache --detail --ignore-catch --strict --update"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export function resolve(
 
   log('looking for:', source)
 
+  source = removeQuerystring(source)
+
   // don't worry about core node modules
   if (isCore(source)) {
     log('matched core:', source)
@@ -134,6 +136,15 @@ function tsResolve(id: string, opts?: SyncOpts): string {
     }
     throw error
   }
+}
+
+/** Remove any trailing querystring from module id. */
+function removeQuerystring(id: string) {
+  const querystringIndex = id.lastIndexOf('?')
+  if (querystringIndex >= 0) {
+    return id.slice(0, querystringIndex)
+  }
+  return id
 }
 
 /** Remove .js or .jsx extension from module id. */

--- a/tests/withQuerystring/.eslintrc.js
+++ b/tests/withQuerystring/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../baseEslintConfig')(__dirname)

--- a/tests/withQuerystring/image.svg
+++ b/tests/withQuerystring/image.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" />
+</svg>

--- a/tests/withQuerystring/index.ts
+++ b/tests/withQuerystring/index.ts
@@ -1,0 +1,7 @@
+// import svg without querystring
+import './image.svg'
+import './subfolder/image.svg'
+
+// import svg with querystring
+import './image.svg?raw'
+import './subfolder/image.svg?raw'

--- a/tests/withQuerystring/subfolder/image.svg
+++ b/tests/withQuerystring/subfolder/image.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" />
+</svg>

--- a/tests/withQuerystring/tsconfig.json
+++ b/tests/withQuerystring/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "files": ["index.ts"]
+}


### PR DESCRIPTION
[Vite](https://vitejs.dev/) supports querystrings in imports like for instance: `import svg from "./image.svg?raw"` (imports the file contents as a string).

Such an import gets wrongly marked as unresolved by the rule `import/no-unresolve` when using this resolver.

The [webpack resolver](https://github.com/benmosher/eslint-plugin-import/tree/master/resolvers/webpack) strips querystrings so that `import/no-unresolve` correctly can resolve those imports.

This PR adds the same feature to `eslint-import-resolver-typescript`.
