### PR TITLE
feature: allow passing through custom options to resolve

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const defaultExtensions = [
 
 export const interfaceVersion = 2
 
-export interface TsResolverOptions {
+export type TsResolverOptions = SyncOpts & {
   alwaysTryTypes?: boolean
   /**
    * @deprecated use `project` instead
@@ -76,6 +76,7 @@ export function resolve(
   let foundNodePath: string | null | undefined
   try {
     foundNodePath = tsResolve(mappedPath ?? source, {
+      ...options,
       extensions: options.extensions ?? defaultExtensions,
       basedir: path.dirname(path.resolve(file)),
       packageFilter: options.packageFilter ?? packageFilterDefault,


### PR DESCRIPTION
letting us pass our own options (via settings in .eslintrc.js allows us to override all of the settings specified in https://www.npmjs.com/package/resolve - not just the ones this project "knows" about. spreading these first will ensure that the settings this project knows about will still work/override as expected while letting others pass through.