### PR TITLE
feat: support `.cjs` `.mjs` `.cts` `.mts` extensions

### DIFF
--- a/tests/withJsExtension/cjsImportee.cjs
+++ b/tests/withJsExtension/cjsImportee.cjs
@@ -1,0 +1,2 @@
+/* eslint-env node */
+module.exports = 'cjsImportee.cjs'

--- a/tests/withJsExtension/ctsImportee.cts
+++ b/tests/withJsExtension/ctsImportee.cts
@@ -1,0 +1,1 @@
+export default 'ctsImportee.cts'

--- a/tests/withJsExtension/d-ctsImportee.d.cts
+++ b/tests/withJsExtension/d-ctsImportee.d.cts
@@ -1,0 +1,3 @@
+declare const content: 'yes'
+
+export = content

--- a/tests/withJsExtension/d-mtsImportee.d.mts
+++ b/tests/withJsExtension/d-mtsImportee.d.mts
@@ -1,0 +1,3 @@
+declare const content: 'yes'
+
+export default content

--- a/tests/withJsExtension/foo.cjs/index.ts
+++ b/tests/withJsExtension/foo.cjs/index.ts
@@ -1,0 +1,1 @@
+export default 'foo.cjs'

--- a/tests/withJsExtension/foo.mjs/index.ts
+++ b/tests/withJsExtension/foo.mjs/index.ts
@@ -1,0 +1,1 @@
+export default 'foo.mjs'

--- a/tests/withJsExtension/jsImportee.js
+++ b/tests/withJsExtension/jsImportee.js
@@ -1,0 +1,1 @@
+export default 'jsImportee.js'

--- a/tests/withJsExtension/jsxImportee.jsx
+++ b/tests/withJsExtension/jsxImportee.jsx
@@ -1,0 +1,1 @@
+export default 'jsxImportee.jsx'

--- a/tests/withJsExtension/mjsImportee.mjs
+++ b/tests/withJsExtension/mjsImportee.mjs
@@ -1,0 +1,1 @@
+export default 'mjsImportee.mjs'

--- a/tests/withJsExtension/mtsImportee.mts
+++ b/tests/withJsExtension/mtsImportee.mts
@@ -1,0 +1,1 @@
+export default 'mtsImportee.mts'

--- a/tests/withJsExtension/test.js
+++ b/tests/withJsExtension/test.js
@@ -26,19 +26,37 @@ function assertResolve(id, relativePath) {
 
 // import relative
 
+assertResolve('./jsImportee.js', 'jsImportee.js')
+
+assertResolve('./cjsImportee.cjs', 'cjsImportee.cjs')
+
+assertResolve('./mjsImportee.mjs', 'mjsImportee.mjs')
+
 assertResolve('./tsImportee.js', 'tsImportee.ts')
 
 assertResolve('./tsxImportee.jsx', 'tsxImportee.tsx')
 
+assertResolve('./ctsImportee.cjs', 'ctsImportee.cts')
+
+assertResolve('./mtsImportee.mjs', 'mtsImportee.mts')
+
 assertResolve('./dtsImportee.js', 'dtsImportee.d.ts')
 
 assertResolve('./dtsImportee.jsx', 'dtsImportee.d.ts')
+
+assertResolve('./d-ctsImportee.cjs', 'd-ctsImportee.d.cts')
+
+assertResolve('./d-mtsImportee.mjs', 'd-mtsImportee.d.mts')
 
 assertResolve('./foo', 'foo/index.ts')
 
 assertResolve('./foo.js', 'foo.js/index.ts')
 
 assertResolve('./foo.jsx', 'foo.jsx/index.ts')
+
+assertResolve('./foo.cjs', 'foo.cjs/index.ts')
+
+assertResolve('./foo.mjs', 'foo.mjs/index.ts')
 
 assertResolve('./bar', 'bar/index.tsx')
 
@@ -48,9 +66,21 @@ assertResolve('#/tsImportee.js', 'tsImportee.ts')
 
 assertResolve('#/tsxImportee.jsx', 'tsxImportee.tsx')
 
+assertResolve('#/cjsImportee.cjs', 'cjsImportee.cjs')
+
+assertResolve('#/mjsImportee.mjs', 'mjsImportee.mjs')
+
+assertResolve('#/ctsImportee.cjs', 'ctsImportee.cts')
+
+assertResolve('#/mtsImportee.mjs', 'mtsImportee.mts')
+
 assertResolve('#/dtsImportee.js', 'dtsImportee.d.ts')
 
 assertResolve('#/dtsImportee.jsx', 'dtsImportee.d.ts')
+
+assertResolve('#/d-ctsImportee.cjs', 'd-ctsImportee.d.cts')
+
+assertResolve('#/d-mtsImportee.mjs', 'd-mtsImportee.d.mts')
 
 assertResolve('#/foo', 'foo/index.ts')
 
@@ -66,9 +96,21 @@ assertResolve('tsImportee.js', 'tsImportee.ts')
 
 assertResolve('tsxImportee.jsx', 'tsxImportee.tsx')
 
+assertResolve('cjsImportee.cjs', 'cjsImportee.cjs')
+
+assertResolve('mjsImportee.mjs', 'mjsImportee.mjs')
+
+assertResolve('ctsImportee.cjs', 'ctsImportee.cts')
+
+assertResolve('mtsImportee.mjs', 'mtsImportee.mts')
+
 assertResolve('dtsImportee.js', 'dtsImportee.d.ts')
 
 assertResolve('dtsImportee.jsx', 'dtsImportee.d.ts')
+
+assertResolve('d-ctsImportee.cjs', 'd-ctsImportee.d.cts')
+
+assertResolve('d-mtsImportee.mjs', 'd-mtsImportee.d.mts')
 
 assertResolve('foo', 'foo/index.ts')
 


### PR DESCRIPTION
close #83

prepare for [`typescript@4.5`](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#new-file-extensions)