### PR TITLE
feat: ignore `node_modules` folder in `projects` option glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "glob": "^7.2.0",
+    "globby": "^11.1.0",
     "is-glob": "^4.0.3",
     "resolve": "^1.22.0",
     "tsconfig-paths": "^4.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,10 +287,15 @@ function initMappers(options: TsResolverOptions) {
       ? options.project
       : [process.cwd()]
 
+  const ignore = ['./node_modules/**']
+
   mappers = configPaths
     // turn glob patterns into paths
     .reduce<string[]>(
-      (paths, path) => [...paths, ...(isGlob(path) ? globSync(path) : [path])],
+      (paths, path) => [
+        ...paths,
+        ...(isGlob(path) ? globSync(path, { ignore }) : [path]),
+      ],
       [],
     )
     .map(loadConfig)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import debug from 'debug'
-import { sync as globSync } from 'glob'
+import { sync as globSync } from 'globby'
 import isGlob from 'is-glob'
 import { isCore, sync, SyncOpts } from 'resolve'
 import {
@@ -287,17 +287,17 @@ function initMappers(options: TsResolverOptions) {
       ? options.project
       : [process.cwd()]
 
-  const ignore = ['./node_modules/**']
+  const ignore = ['!**/node_modules/**']
 
-  mappers = configPaths
-    // turn glob patterns into paths
-    .reduce<string[]>(
-      (paths, path) => [
-        ...paths,
-        ...(isGlob(path) ? globSync(path, { ignore }) : [path]),
-      ],
-      [],
-    )
+  // turn glob patterns into paths
+  const projectPaths = [
+    ...new Set([
+      ...configPaths.filter(path => !isGlob(path)),
+      ...globSync([...configPaths.filter(path => isGlob(path)), ...ignore]),
+    ]),
+  ]
+
+  mappers = projectPaths
     .map(loadConfig)
     .filter(isConfigLoaderSuccessResult)
     .map(configLoaderResult => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5317,9 +5317,9 @@ globby@10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@^11.0.1, globby@^11.0.4:
+globby@^11.0.1, globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
   dependencies:
     array-union "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5319,7 +5319,7 @@ globby@10.0.1:
 
 globby@^11.0.1, globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
-  resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
   dependencies:
     array-union "^2.1.0"


### PR DESCRIPTION
this ensures to not include the `node_modules` folder when expanding the `projects` option glob.

(similar to what `@typescript-eslint/parser` does, but with `globby` not `glob`, see https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/parser.ts#L296-L306)